### PR TITLE
Update to work with Couchbase 6.0 server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 DISCONTINUED AT THE MOMENT
 If needed I can work on it again.
 
-A Clojure java-client wrapper for Couchbase Server 4.
+A Clojure java-client wrapper for Couchbase Server 4. Now updated to support 6.0 with Couchbase Java client version 2.7.9.
 
 ## Usage
 
@@ -17,6 +17,12 @@ A Clojure java-client wrapper for Couchbase Server 4.
     
     ;; we create a bucket
     (def bucket (c/open-bucket cluster "gamesim-sample"))
+
+    ;; we authenticate with the bucket password, note: the password parameter on the c/bucket-open
+    ;; no longer works and you will get the exception MixedAuthenticationException
+    ;; Mixed mode authentication not allowed, use Bucket credentials, User credentials (rbac) or Certificate auth
+
+    (c/authenticate "gamesim-sample" "secret")
     
     ;; we get documents from bucket mapped
     (b/get bucket "Aaron1")

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/Earthen/clj-cb"
   :license {:name "Apache Public License"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/data.json "0.2.6"]
-                 [com.couchbase.client/java-client "2.2.8"]]
+                 [com.couchbase.client/java-client "2.7.9"]]
   :plugins [[lein-codox "0.9.4"]])

--- a/src/earthen/clj_cb/cluster.clj
+++ b/src/earthen/clj_cb/cluster.clj
@@ -15,7 +15,6 @@
 (defn authenticate
   "Login to cluster"
   [cluster username password]
-  (println (type cluster))
   (.authenticate cluster username password))
   
 

--- a/src/earthen/clj_cb/cluster.clj
+++ b/src/earthen/clj_cb/cluster.clj
@@ -22,12 +22,8 @@
   "Open a bucket from a the cluster"
   ([cluster bucket-name]
    (open-bucket cluster bucket-name 20 :SECONDS))
-  ([cluster bucket-name password]
-   (open-bucket cluster bucket-name password 20 :SECONDS))
   ([cluster bucket-name time time-type]
-   (.openBucket cluster bucket-name time (u/time time-type)))
-  ([cluster bucket-name password time time-type]
-   (.openBucket cluster bucket-name password time (u/time time-type))))
+   (.openBucket cluster bucket-name time (u/time time-type))))
 
 (defn manager
   "Returns a cluster manager giving a cluster and credentials"

--- a/src/earthen/clj_cb/cluster.clj
+++ b/src/earthen/clj_cb/cluster.clj
@@ -12,12 +12,23 @@
    (let [urls (if (string? string) (vector string) string)]
      (CouchbaseCluster/create urls))))
 
+(defn authenticate
+  "Login to cluster"
+  [cluster username password]
+  (println (type cluster))
+  (.authenticate cluster username password))
+  
+
 (defn open-bucket
   "Open a bucket from a the cluster"
   ([cluster bucket-name]
    (open-bucket cluster bucket-name 20 :SECONDS))
+  ([cluster bucket-name password]
+   (open-bucket cluster bucket-name password 20 :SECONDS))
   ([cluster bucket-name time time-type]
-   (.openBucket cluster bucket-name time (u/time time-type))))
+   (.openBucket cluster bucket-name time (u/time time-type)))
+  ([cluster bucket-name password time time-type]
+   (.openBucket cluster bucket-name password time (u/time time-type))))
 
 (defn manager
   "Returns a cluster manager giving a cluster and credentials"

--- a/test/clj_cb/fixtures.clj
+++ b/test/clj_cb/fixtures.clj
@@ -9,7 +9,7 @@
                               :type :COUCHBASE
                               :quota 100
                               :port 0
-                              :password ""
+                              :password "earthen_test"
                               :replicas 0
                               :index-replicas false
                               :flush? true})
@@ -32,6 +32,8 @@
 
 (defn init
   [f]
+  (c/authenticate cluster "earthen" "earthen")
   (c/remove-bucket! manager bucket-name)
   (c/insert-bucket! manager default-bucket-settings)
   (f))
+

--- a/test/earthen/clj_cb/bucket_test.clj
+++ b/test/earthen/clj_cb/bucket_test.clj
@@ -8,10 +8,19 @@
            :year 2000
            :pages 12})
 
-(use-fixtures :once fx/init)
+(use-fixtures :each fx/init)
 
 (deftest crud
+  (fx/authenticate "earthen" "earthen")
   (let [item (b/replace! (fx/bucket) (:name book) book)]
     (is (= book (:content item)) "insert/replace")
     (is (= item (b/get (fx/bucket) (:name book))))))
 
+(deftest crud-authentication-fail
+  (fx/authenticate "earthen" "notearthen")
+  (is (thrown-with-msg?  com.couchbase.client.java.error.InvalidPasswordException
+                         #"Passwords for bucket \"earthen_test\" do not match."
+                         (b/replace! (fx/bucket) (:name book) book)))
+  (is (thrown-with-msg?  com.couchbase.client.java.error.InvalidPasswordException
+                         #"Passwords for bucket \"earthen_test\" do not match."
+                         (b/get (fx/bucket) (:name book)))))

--- a/test/earthen/clj_cb/bucket_test.clj
+++ b/test/earthen/clj_cb/bucket_test.clj
@@ -1,8 +1,8 @@
-(ns clj-cb.bucket-test
+(ns earthen.clj-cb.bucket-test
   (:require [clojure.test :refer :all]
             [earthen.clj-cb.bucket :as b]
             [earthen.clj-cb.utils :as u]
-            [clj-cb.fixtures :as fx]))
+            [earthen.clj-cb.fixtures :as fx]))
 
 (def book {:name "living-clojure"
            :year 2000

--- a/test/earthen/clj_cb/cluster_test.clj
+++ b/test/earthen/clj_cb/cluster_test.clj
@@ -1,8 +1,8 @@
-(ns clj-cb.cluster-test
+(ns earthen.clj-cb.cluster-test
   (:require [clojure.test :refer :all]
             [earthen.clj-cb.cluster :as c]
             [earthen.clj-cb.utils :as u]
-            [clj-cb.fixtures :as fx]))
+            [earthen.clj-cb.fixtures :as fx]))
 
 (use-fixtures :once fx/init)
 
@@ -15,10 +15,9 @@
     (is (= fx/bucket-name (->> (c/buckets (fx/manager)) (map :name) (some #{fx/bucket-name}))) "no bucket is created"))
   (testing "creating insert-bucket!"
     (let [created-bucket (get-bucket fx/bucket-name)]
-      (is (= fx/default-bucket-settings created-bucket)))))
+      (is (= (dissoc fx/default-bucket-settings :password) (dissoc created-bucket :password))))))
 
 (deftest disconnect
   (testing "disconnect"
     (is (= true (c/disconnect fx/cluster)))))
-
 

--- a/test/earthen/clj_cb/cluster_test.clj
+++ b/test/earthen/clj_cb/cluster_test.clj
@@ -19,5 +19,5 @@
 
 (deftest disconnect
   (testing "disconnect"
-    (is (= true (c/disconnect fx/cluster)))))
+    (is (= true (c/disconnect @fx/cluster)))))
 

--- a/test/earthen/clj_cb/fixtures.clj
+++ b/test/earthen/clj_cb/fixtures.clj
@@ -1,4 +1,4 @@
-(ns clj-cb.fixtures
+(ns earthen.clj-cb.fixtures
   (:require [clojure.test :refer :all]
             [earthen.clj-cb.cluster :as c]
             [earthen.clj-cb.cluster]))
@@ -33,7 +33,9 @@
 (defn init
   [f]
   (c/authenticate cluster "earthen" "earthen")
-  (c/remove-bucket! manager bucket-name)
-  (c/insert-bucket! manager default-bucket-settings)
+  (c/remove-bucket! (manager) bucket-name)
+  (c/insert-bucket! (manager) default-bucket-settings)
   (f))
+
+(init +)
 

--- a/test/earthen/clj_cb/fixtures.clj
+++ b/test/earthen/clj_cb/fixtures.clj
@@ -11,7 +11,7 @@
                               :type :COUCHBASE
                               :quota 100
                               :port 0
-                              :password "earthen_test"
+                              :password ""
                               :replicas 0
                               :index-replicas false
                               :flush? true})

--- a/test/earthen/clj_cb/fixtures.clj
+++ b/test/earthen/clj_cb/fixtures.clj
@@ -3,7 +3,6 @@
             [earthen.clj-cb.cluster :as c]
             [earthen.clj-cb.cluster]))
 
-;(def cluster (c/create))
 (def cluster (atom nil))
 
 (def bucket-name "earthen_test")

--- a/test/earthen/clj_cb/fixtures.clj
+++ b/test/earthen/clj_cb/fixtures.clj
@@ -22,7 +22,7 @@
 
 (defn manager
   []
-  (c/manager @cluster {:username "Administrator" :password "unix11"}))
+  (c/manager @cluster {:username "Administrator" :password "Admin123"}))
 
 ;; (defn init-bucket
 ;;   [f]

--- a/test/earthen/clj_cb/fixtures.clj
+++ b/test/earthen/clj_cb/fixtures.clj
@@ -3,7 +3,9 @@
             [earthen.clj-cb.cluster :as c]
             [earthen.clj-cb.cluster]))
 
-(def cluster (c/create))
+;(def cluster (c/create))
+(def cluster (atom nil))
+
 (def bucket-name "earthen_test")
 (def default-bucket-settings {:name bucket-name
                               :type :COUCHBASE
@@ -16,11 +18,11 @@
 
 (defn bucket
   []
-  (c/open-bucket cluster bucket-name))
+  (c/open-bucket @cluster bucket-name))
 
 (defn manager
   []
-  (c/manager cluster {:username "earthen" :password "earthen"}))
+  (c/manager @cluster {:username "Administrator" :password "unix11"}))
 
 ;; (defn init-bucket
 ;;   [f]
@@ -30,12 +32,17 @@
 ;;         manager (c/manager cluster {:username "earthen" :password "earthen"})]
 ;;     (f)))
 
+(defn authenticate
+  [username password]
+  (c/authenticate @cluster username password))
+
 (defn init
   [f]
-  (c/authenticate cluster "earthen" "earthen")
+  (reset! cluster (c/create))
   (c/remove-bucket! (manager) bucket-name)
   (c/insert-bucket! (manager) default-bucket-settings)
-  (f))
-
-(init +)
+  (f)
+  (try
+    (c/disconnect @cluster)
+    (catch java.util.concurrent.RejectedExecutionException e (println (str "Caught Expected Exception " e)))))
 


### PR DESCRIPTION
Hi, I added a cluster/authenticate function to support the new RBAC based authentication in the newer versions of Couchbase. The Clojure version has been updated to 1.10 and the Couchbase Java client to 2.7.9. To run the tests two security accounts must exist in the DB, Administrator / Admin123 and a user with access to the earthen_test bucket, earthen / earthen. The tests have been changed to close the cluster down between each iteration or else the client warns about duplicate clusters. Closing is also necessary as the authenticator persists in the session and subsequent calls to c/authenticate are ignored. The passwords in the tests also cannot be compared as the password that comes back from Couchbase is encrypted. Hence the dissoc to remove it before comparison.